### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/demo/anti_flood_ftpd.py
+++ b/demo/anti_flood_ftpd.py
@@ -75,8 +75,8 @@ class AntiFloodHandler(FTPHandler):
     def ban(self, ip):
         # ban ip and schedule next un-ban
         if ip not in self.banned_ips:
-            self.log('banned IP %s for command flooding' % ip)
-        self.respond('550 You are banned for %s seconds.' % self.ban_for)
+            self.log('banned IP {0!s} for command flooding'.format(ip))
+        self.respond('550 You are banned for {0!s} seconds.'.format(self.ban_for))
         self.close()
         self.banned_ips.append(ip)
 
@@ -87,7 +87,7 @@ class AntiFloodHandler(FTPHandler):
         except ValueError:
             pass
         else:
-            self.log('unbanning IP %s' % ip)
+            self.log('unbanning IP {0!s}'.format(ip))
 
     def close(self):
         FTPHandler.close(self)

--- a/demo/unix_daemon.py
+++ b/demo/unix_daemon.py
@@ -124,7 +124,7 @@ def stop():
         except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ESRCH:
-                print_("\nstopped (pid %s)" % pid)
+                print_("\nstopped (pid {0!s})".format(pid))
                 return
             else:
                 raise
@@ -132,7 +132,7 @@ def stop():
         if i == 25:
             sig = signal.SIGKILL
         elif i == 50:
-            sys.exit("\ncould not kill daemon (pid %s)" % pid)
+            sys.exit("\ncould not kill daemon (pid {0!s})".format(pid))
         time.sleep(0.1)
 
 
@@ -142,7 +142,7 @@ def status():
     if not pid or not pid_exists(pid):
         print_("daemon not running")
     else:
-        print_("daemon running with pid %s" % pid)
+        print_("daemon running with pid {0!s}".format(pid))
     sys.exit(0)
 
 
@@ -187,13 +187,13 @@ def daemonize():
         # write pidfile
         pid = str(os.getpid())
         f = open(PID_FILE, 'w')
-        f.write("%s\n" % pid)
+        f.write("{0!s}\n".format(pid))
         f.close()
         atexit.register(lambda: os.remove(PID_FILE))
 
     pid = get_pid()
     if pid and pid_exists(pid):
-        sys.exit('daemon already running (pid %s)' % pid)
+        sys.exit('daemon already running (pid {0!s})'.format(pid))
     # instance FTPd before daemonizing, so that in case of problems we
     # get an exception here and exit immediately
     server = get_server()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = PROJECT_NAME
-copyright = u('2009-%s, %s' % (THIS_YEAR, AUTHOR))
+copyright = u('2009-{0!s}, {1!s}'.format(THIS_YEAR, AUTHOR))
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -208,7 +208,7 @@ html_use_index = True
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '%s-doc' % PROJECT_NAME
+htmlhelp_basename = '{0!s}-doc'.format(PROJECT_NAME)
 
 # -- Options for LaTeX output ------------------------------------------------
 
@@ -222,7 +222,7 @@ htmlhelp_basename = '%s-doc' % PROJECT_NAME
 # (source start file, target name, title, author, documentclass
 # [howto/manual]).
 latex_documents = [
-    ('index', '%s.tex' % PROJECT_NAME,
+    ('index', '{0!s}.tex'.format(PROJECT_NAME),
      u('%s documentation') % PROJECT_NAME, AUTHOR),
 ]
 

--- a/pyftpdlib/__main__.py
+++ b/pyftpdlib/__main__.py
@@ -50,9 +50,9 @@ class CustomizedOptionFormatter(optparse.IndentedHelpFormatter):
     def format_option(self, option):
         result = []
         opts = self.option_strings[option]
-        result.append('  %s\n' % opts)
+        result.append('  {0!s}\n'.format(opts))
         if option.help:
-            help_text = '     %s\n\n' % self.expand_default(option)
+            help_text = '     {0!s}\n\n'.format(self.expand_default(option))
             result.append(help_text)
         return ''.join(result)
 
@@ -85,7 +85,7 @@ def main():
 
     options, args = parser.parse_args()
     if options.version:
-        sys.exit("pyftpdlib %s" % __ver__)
+        sys.exit("pyftpdlib {0!s}".format(__ver__))
     if options.verbose:
         import logging
         import pyftpdlib.log

--- a/pyftpdlib/authorizers.py
+++ b/pyftpdlib/authorizers.py
@@ -123,11 +123,11 @@ class DummyAuthorizer(object):
         provide customized response strings when user log-in and quit.
         """
         if self.has_user(username):
-            raise ValueError('user %r already exists' % username)
+            raise ValueError('user {0!r} already exists'.format(username))
         if not isinstance(homedir, unicode):
             homedir = homedir.decode('utf8')
         if not os.path.isdir(homedir):
-            raise ValueError('no such directory: %r' % homedir)
+            raise ValueError('no such directory: {0!r}'.format(homedir))
         homedir = os.path.realpath(homedir)
         self._check_permissions(username, perm)
         dic = {'pwd': str(password),
@@ -165,7 +165,7 @@ class DummyAuthorizer(object):
         """Override permissions for a given directory."""
         self._check_permissions(username, perm)
         if not os.path.isdir(directory):
-            raise ValueError('no such directory: %r' % directory)
+            raise ValueError('no such directory: {0!r}'.format(directory))
         directory = os.path.normcase(os.path.realpath(directory))
         home = os.path.normcase(self.get_home_dir(username))
         if directory == home:
@@ -256,7 +256,7 @@ class DummyAuthorizer(object):
         warned = 0
         for p in perm:
             if p not in self.read_perms + self.write_perms:
-                raise ValueError('no such permission %r' % p)
+                raise ValueError('no such permission {0!r}'.format(p))
             if (username == 'anonymous'
                     and p in self.write_perms
                     and not warned):
@@ -310,15 +310,14 @@ class _Base(object):
             if user == 'anonymous':
                 raise AuthorizerError('invalid username "anonymous"')
             if user not in users:
-                raise AuthorizerError('unknown user %s' % user)
+                raise AuthorizerError('unknown user {0!s}'.format(user))
 
         if self.anonymous_user is not None:
             if not self.has_user(self.anonymous_user):
-                raise AuthorizerError('no such user %s' % self.anonymous_user)
+                raise AuthorizerError('no such user {0!s}'.format(self.anonymous_user))
             home = self.get_home_dir(self.anonymous_user)
             if not os.path.isdir(home):
-                raise AuthorizerError('no valid home set for user %s'
-                                      % self.anonymous_user)
+                raise AuthorizerError('no valid home set for user {0!s}'.format(self.anonymous_user))
 
     def override_user(self, username, password=None, homedir=None, perm=None,
                       msg_login=None, msg_quit=None):
@@ -330,13 +329,13 @@ class _Base(object):
             raise AuthorizerError(
                 "at least one keyword argument must be specified")
         if self.allowed_users and username not in self.allowed_users:
-            raise AuthorizerError('%s is not an allowed user' % username)
+            raise AuthorizerError('{0!s} is not an allowed user'.format(username))
         if self.rejected_users and username in self.rejected_users:
-            raise AuthorizerError('%s is not an allowed user' % username)
+            raise AuthorizerError('{0!s} is not an allowed user'.format(username))
         if username == "anonymous" and password:
             raise AuthorizerError("can't assign password to anonymous user")
         if not self.has_user(username):
-            raise AuthorizerError('no such user %s' % username)
+            raise AuthorizerError('no such user {0!s}'.format(username))
         if homedir is not None and not isinstance(homedir, unicode):
             homedir = homedir.decode('utf8')
 
@@ -418,7 +417,7 @@ else:
                 try:
                     pwd.getpwnam(self.anonymous_user).pw_dir
                 except KeyError:
-                    raise AuthorizerError('no such user %s' % anonymous_user)
+                    raise AuthorizerError('no such user {0!s}'.format(anonymous_user))
 
         # --- overridden / private API
 
@@ -580,8 +579,7 @@ else:
             if require_valid_shell:
                 for username in self.allowed_users:
                     if not self._has_valid_shell(username):
-                        raise AuthorizerError("user %s has not a valid shell"
-                                              % username)
+                        raise AuthorizerError("user {0!s} has not a valid shell".format(username))
 
         def override_user(self, username, password=None, homedir=None,
                           perm=None, msg_login=None, msg_quit=None):
@@ -745,7 +743,7 @@ else:
                 key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, path)
             except WindowsError:
                 raise AuthorizerError(
-                    "No profile directory defined for user %s" % username)
+                    "No profile directory defined for user {0!s}".format(username))
             value = winreg.QueryValueEx(key, "ProfileImagePath")[0]
             home = win32api.ExpandEnvironmentStrings(value)
             if not PY3 and not isinstance(home, unicode):

--- a/pyftpdlib/filesystems.py
+++ b/pyftpdlib/filesystems.py
@@ -480,14 +480,14 @@ class AbstractedFS(object):
             else:
                 fmtstr = "%d %H:%M"
             try:
-                mtimestr = "%s %s" % (_months_map[mtime.tm_mon],
+                mtimestr = "{0!s} {1!s}".format(_months_map[mtime.tm_mon],
                                       time.strftime(fmtstr, mtime))
             except ValueError:
                 # It could be raised if last mtime happens to be too
                 # old (prior to year 1900) in which case we return
                 # the current time as last mtime.
                 mtime = timefunc()
-                mtimestr = "%s %s" % (_months_map[mtime.tm_mon],
+                mtimestr = "{0!s} {1!s}".format(_months_map[mtime.tm_mon],
                                       time.strftime("%d %H:%M", mtime))
 
             # same as stat.S_ISLNK(st.st_mode) but slighlty faster
@@ -502,7 +502,7 @@ class AbstractedFS(object):
                         raise
 
             # formatting is matched with proftpd ls output
-            line = "%s %3s %-8s %-8s %8s %s %s\r\n" % (
+            line = "{0!s} {1:3!s} {2:<8!s} {3:<8!s} {4:8!s} {5!s} {6!s}\r\n".format(
                 perms, nlinks, uname, gname, size, mtimestr, basename)
             yield line.encode('utf8', self.cmd_channel.unicode_errors)
 
@@ -632,12 +632,12 @@ class AbstractedFS(object):
             # platforms should use some platform-specific method (e.g.
             # on Windows NTFS filesystems MTF records could be used).
             if show_unique:
-                retfacts['unique'] = "%xg%x" % (st.st_dev, st.st_ino)
+                retfacts['unique'] = "{0:x}g{1:x}".format(st.st_dev, st.st_ino)
 
             # facts can be in any order but we sort them by name
-            factstring = "".join(["%s=%s;" % (x, retfacts[x])
+            factstring = "".join(["{0!s}={1!s};".format(x, retfacts[x])
                                   for x in sorted(retfacts.keys())])
-            line = "%s %s\r\n" % (factstring, basename)
+            line = "{0!s} {1!s}\r\n".format(factstring, basename)
             yield line.encode('utf8', self.cmd_channel.unicode_errors)
 
 

--- a/pyftpdlib/ioloop.py
+++ b/pyftpdlib/ioloop.py
@@ -180,7 +180,7 @@ class _CallLater(object):
                  '_repush', 'timeout', 'cancelled')
 
     def __init__(self, seconds, target, *args, **kwargs):
-        assert callable(target), "%s is not callable" % target
+        assert callable(target), "{0!s} is not callable".format(target)
         assert MAXSIZE >= seconds >= 0, "%s is not greater than or equal " \
                                         "to 0 seconds" % seconds
         self._delay = seconds
@@ -209,10 +209,10 @@ class _CallLater(object):
             sig = object.__repr__(self)
         else:
             sig = repr(self._target)
-        sig += ' args=%s, kwargs=%s, cancelled=%s, secs=%s' % (
+        sig += ' args={0!s}, kwargs={1!s}, cancelled={2!s}, secs={3!s}'.format(
             self._args or '[]', self._kwargs or '{}', self.cancelled,
             self._delay)
-        return '<%s>' % sig
+        return '<{0!s}>'.format(sig)
 
     __str__ = __repr__
 

--- a/pyftpdlib/log.py
+++ b/pyftpdlib/log.py
@@ -110,7 +110,7 @@ class LogFormatter(logging.Formatter):
             record.message = record.getMessage()
         except Exception:
             err = sys.exc_info()[1]
-            record.message = "Bad message (%r): %r" % (err, record.__dict__)
+            record.message = "Bad message ({0!r}): {1!r}".format(err, record.__dict__)
 
         record.asctime = time.strftime(TIME_FORMAT,
                                        self.converter(record.created))

--- a/pyftpdlib/servers.py
+++ b/pyftpdlib/servers.py
@@ -169,7 +169,7 @@ class FTPServer(Acceptor):
             _config_logging()
 
         if self.handler.passive_ports:
-            pasv_ports = "%s->%s" % (self.handler.passive_ports[0],
+            pasv_ports = "{0!s}->{1!s}".format(self.handler.passive_ports[0],
                                      self.handler.passive_ports[-1])
         else:
             pasv_ports = None
@@ -178,8 +178,7 @@ class FTPServer(Acceptor):
             proto = "FTP+SSL"
         else:
             proto = "FTP"
-        logger.info(">>> starting %s server on %s:%s, pid=%i <<<"
-                    % (proto, addr[0], addr[1], os.getpid()))
+        logger.info(">>> starting {0!s} server on {1!s}:{2!s}, pid={3:d} <<<".format(proto, addr[0], addr[1], os.getpid()))
         logger.info("poller: %r", self.ioloop.__class__)
         logger.info("masquerade (NAT) address: %s",
                     self.handler.masquerade_address)
@@ -472,7 +471,7 @@ class _SpawnerBase(FTPServer):
                 # in case also other threads/processes are hanging.
                 self.join_timeout = None
                 if hasattr(t, 'terminate'):
-                    msg = "could not terminate process %r" % t
+                    msg = "could not terminate process {0!r}".format(t)
                     if not _BSD:
                         warn(msg + "; sending SIGKILL as last resort")
                         try:

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def hilite(s, ok=True, bold=False):
             attr.append('31')
         if bold:
             attr.append('1')
-        return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), s)
+        return '\x1b[{0!s}m{1!s}\x1b[0m'.format(';'.join(attr), s)
 
 
 if sys.version_info < (2, 4):

--- a/test/bench.py
+++ b/test/bench.py
@@ -151,18 +151,18 @@ else:
             attr.append('31')
         if bold:
             attr.append('1')
-        return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), string)
+        return '\x1b[{0!s}m{1!s}\x1b[0m'.format(';'.join(attr), string)
 
 
 server_memory = []
 
 
 def print_bench(what, value, unit=""):
-    s = "%s %s %-8s" % (hilite("%-50s" % what, ok=None, bold=0),
-                        hilite("%8.2f" % value),
+    s = "{0!s} {1!s} {2:<8!s}".format(hilite("{0:<50!s}".format(what), ok=None, bold=0),
+                        hilite("{0:8.2f}".format(value)),
                         unit)
     if server_memory:
-        s += "%s" % hilite(server_memory.pop())
+        s += "{0!s}".format(hilite(server_memory.pop()))
     print_(s.strip())
 
 
@@ -418,17 +418,17 @@ class OptFormatter(optparse.IndentedHelpFormatter):
     def format_option(self, option):
         result = []
         opts = self.option_strings[option]
-        result.append('  %s\n' % opts)
+        result.append('  {0!s}\n'.format(opts))
         if option.help:
-            help_text = '     %s\n\n' % self.expand_default(option)
+            help_text = '     {0!s}\n\n'.format(self.expand_default(option))
             result.append(help_text)
         return ''.join(result)
 
 
 def main():
     global HOST, PORT, USER, PASSWORD, SERVER_PROC, TIMEOUT
-    USAGE = "%s -u USERNAME -p PASSWORD [-H] [-P] [-b] [-n] [-s] [-k]" % (
-        __file__)
+    USAGE = "{0!s} -u USERNAME -p PASSWORD [-H] [-P] [-b] [-n] [-s] [-k]".format((
+        __file__))
     parser = optparse.OptionParser(usage=USAGE,
                                    epilog=__doc__[__doc__.find('Example'):],
                                    formatter=OptFormatter())
@@ -466,7 +466,7 @@ def main():
         try:
             FILE_SIZE = human2bytes(options.filesize)
         except (ValueError, AssertionError):
-            parser.error("invalid file size %r" % options.filesize)
+            parser.error("invalid file size {0!r}".format(options.filesize))
         if options.pid is not None:
             if psutil is None:
                 raise ImportError("-p option requires psutil module")
@@ -491,7 +491,7 @@ def main():
             resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
 
         def bench_multi_connect():
-            with timethis("%i concurrent clients (connect, login)" % howmany):
+            with timethis("{0:d} concurrent clients (connect, login)".format(howmany)):
                 clients = []
                 for x in range(howmany):
                     clients.append(connect())
@@ -500,7 +500,7 @@ def main():
 
         def bench_multi_retr(clients):
             stor(clients[0], FILE_SIZE)
-            with timethis("%s concurrent clients (RETR %s file)" % (
+            with timethis("{0!s} concurrent clients (RETR {1!s} file)".format(
                     howmany, bytes2human(FILE_SIZE))):
                 for ftp in clients:
                     ftp.voidcmd('TYPE I')
@@ -512,7 +512,7 @@ def main():
                 ftp.voidresp()
 
         def bench_multi_stor(clients):
-            with timethis("%s concurrent clients (STOR %s file)" % (
+            with timethis("{0!s} concurrent clients (STOR {1!s} file)".format(
                     howmany, bytes2human(FILE_SIZE))):
                 for ftp in clients:
                     ftp.voidcmd('TYPE I')
@@ -526,12 +526,12 @@ def main():
         def bench_multi_quit(clients):
             for ftp in clients:
                 AsyncQuit(ftp.sock)
-            with timethis("%i concurrent clients (QUIT)" % howmany):
+            with timethis("{0:d} concurrent clients (QUIT)".format(howmany)):
                 asyncore.loop(use_poll=True)
 
         clients = bench_multi_connect()
-        bench_stor("STOR (1 file with %s idle clients)" % len(clients))
-        bench_retr("RETR (1 file with %s idle clients)" % len(clients))
+        bench_stor("STOR (1 file with {0!s} idle clients)".format(len(clients)))
+        bench_retr("RETR (1 file with {0!s} idle clients)".format(len(clients)))
         bench_multi_retr(clients)
         bench_multi_stor(clients)
         bench_multi_quit(clients)
@@ -548,8 +548,8 @@ def main():
     # start benchmark
     if SERVER_PROC is not None:
         register_memory()
-        print_("(starting with %s of memory being used)" % (
-            hilite(server_memory.pop())))
+        print_("(starting with {0!s} of memory being used)".format((
+            hilite(server_memory.pop()))))
     if options.benchmark == 'transfer':
         bench_stor()
         bench_retr()
@@ -560,7 +560,7 @@ def main():
         bench_retr()
         bench_multi()
     else:
-        sys.exit("invalid 'benchmark' parameter %r" % options.benchmark)
+        sys.exit("invalid 'benchmark' parameter {0!r}".format(options.benchmark))
 
 if __name__ == '__main__':
     main()

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -408,13 +408,13 @@ class TestFTPS(unittest.TestCase):
             why = sys.exc_info()[1]
             if str(why) == msg:
                 return
-            raise self.failureException("%s != %s" % (str(why), msg))
+            raise self.failureException("{0!s} != {1!s}".format(str(why), msg))
         else:
             if hasattr(excClass, '__name__'):
                 excName = excClass.__name__
             else:
                 excName = str(excClass)
-            raise self.failureException("%s not raised" % excName)
+            raise self.failureException("{0!s} not raised".format(excName))
 
     def test_auth(self):
         # unsecured
@@ -589,13 +589,13 @@ class _SharedAuthorizerTests(object):
             why = sys.exc_info()[1]
             if str(why) == msg:
                 return
-            raise self.failureException("%s != %s" % (str(why), msg))
+            raise self.failureException("{0!s} != {1!s}".format(str(why), msg))
         else:
             if hasattr(excClass, '__name__'):
                 excName = excClass.__name__
             else:
                 excName = str(excClass)
-            raise self.failureException("%s not raised" % excName)
+            raise self.failureException("{0!s} not raised".format(excName))
     # --- /utils
 
     def test_get_home_dir(self):
@@ -690,10 +690,10 @@ class _SharedAuthorizerTests(object):
             self.authorizer_class, rejected_users=['anonymous'])
         self.assertRaisesWithMsg(
             AuthorizerError,
-            'unknown user %s' % wrong_user,
+            'unknown user {0!s}'.format(wrong_user),
             self.authorizer_class, allowed_users=[wrong_user])
         self.assertRaisesWithMsg(AuthorizerError,
-                                 'unknown user %s' % wrong_user,
+                                 'unknown user {0!s}'.format(wrong_user),
                                  self.authorizer_class,
                                  rejected_users=[wrong_user])
 
@@ -765,7 +765,7 @@ class _SharedAuthorizerTests(object):
             "at least one keyword argument must be specified",
             auth.override_user, this_user)
         self.assertRaisesWithMsg(AuthorizerError,
-                                 'no such user %s' % nonexistent_user,
+                                 'no such user {0!s}'.format(nonexistent_user),
                                  auth.override_user, nonexistent_user,
                                  perm='r')
         if self.authorizer_class.__name__ == 'UnixAuthorizer':
@@ -775,7 +775,7 @@ class _SharedAuthorizerTests(object):
             auth = self.authorizer_class(allowed_users=[this_user])
         auth.override_user(this_user, perm='r')
         self.assertRaisesWithMsg(AuthorizerError,
-                                 '%s is not an allowed user' % another_user,
+                                 '{0!s} is not an allowed user'.format(another_user),
                                  auth.override_user, another_user, perm='r')
         if self.authorizer_class.__name__ == 'UnixAuthorizer':
             auth = self.authorizer_class(rejected_users=[this_user],
@@ -784,7 +784,7 @@ class _SharedAuthorizerTests(object):
             auth = self.authorizer_class(rejected_users=[this_user])
         auth.override_user(another_user, perm='r')
         self.assertRaisesWithMsg(AuthorizerError,
-                                 '%s is not an allowed user' % this_user,
+                                 '{0!s} is not an allowed user'.format(this_user),
                                  auth.override_user, this_user, perm='r')
         self.assertRaisesWithMsg(AuthorizerError,
                                  "can't assign password to anonymous user",
@@ -873,7 +873,7 @@ class TestUnixAuthorizer(_SharedAuthorizerTests, unittest.TestCase):
         user = get_fake_shell_user()
         self.assertRaisesWithMsg(
             AuthorizerError,
-            "user %s has not a valid shell" % user,
+            "user {0!s} has not a valid shell".format(user),
             authorizers.UnixAuthorizer, allowed_users=[user])
         # commented as it first fails for invalid home
         # self.assertRaisesWithMsg(
@@ -884,7 +884,7 @@ class TestUnixAuthorizer(_SharedAuthorizerTests, unittest.TestCase):
         self.assertTrue(auth._has_valid_shell(self.get_current_user()))
         self.assertFalse(auth._has_valid_shell(user))
         self.assertRaisesWithMsg(AuthorizerError,
-                                 "User %s doesn't have a valid shell." % user,
+                                 "User {0!s} doesn't have a valid shell.".format(user),
                                  auth.override_user, user, perm='r')
 
     def test_not_root(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyftpdlib?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyftpdlib?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
